### PR TITLE
Add metrics for gateway messaging

### DIFF
--- a/docker/sandbox.Dockerfile
+++ b/docker/sandbox.Dockerfile
@@ -10,10 +10,12 @@ RUN apt-get update && apt-get install -y \
 # Create non-root user
 RUN useradd --create-home --shell /bin/bash sandbox
 WORKDIR /home/sandbox
-USER sandbox
 
-# Install Python dependencies
+# Install Python dependencies as root
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+# Drop privileges for runtime
+USER sandbox
 
 CMD ["python", "-c", "print('sandbox ready')"]

--- a/docs/a2a-communication-guide.md
+++ b/docs/a2a-communication-guide.md
@@ -33,3 +33,9 @@ The consensus engine is a key component of the A2A communication system. It allo
 ## Agent Factory
 
 The agent factory is responsible for creating and managing agents. It can be used to dynamically create new agents as needed, and to scale the number of agents up or down based on the workload.
+
+## Monitoring
+
+The WebSocket gateway exposes Prometheus metrics for active connections and A2A
+message throughput. Counters track messages sent and received per service so
+that dashboards can display real-time communication rates.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,8 @@ To set up the project, run the following command:
 make quick-start-a2a
 ```
 
-This will start all the services and run the database migrations.
+This will start all the services and run the database migrations using
+Alembic.
 
 ## Usage
 

--- a/src/common/metrics.py
+++ b/src/common/metrics.py
@@ -102,6 +102,20 @@ CACHE_HIT_RATIO = Gauge(
     registry=default_registry,
 )
 
+# Messaging metrics
+A2A_MESSAGES_SENT = Counter(
+    "mcp_a2a_messages_sent_total",
+    "Total A2A messages sent",
+    ["service"],
+    registry=default_registry,
+)
+A2A_MESSAGES_RECEIVED = Counter(
+    "mcp_a2a_messages_received_total",
+    "Total A2A messages received",
+    ["service"],
+    registry=default_registry,
+)
+
 
 class MetricsCollector:
     """Enhanced metrics collector with context managers and utilities."""
@@ -226,6 +240,14 @@ class MetricsCollector:
                 CACHE_HIT_RATIO.labels(
                     service=self.service_name, cache_type="default"
                 ).set(hit_ratio)
+
+    def record_message_sent(self) -> None:
+        """Increment count of messages sent."""
+        A2A_MESSAGES_SENT.labels(service=self.service_name).inc()
+
+    def record_message_received(self) -> None:
+        """Increment count of messages received."""
+        A2A_MESSAGES_RECEIVED.labels(service=self.service_name).inc()
 
     def get_service_stats(self) -> Dict[str, Any]:
         """Get service-specific statistics."""

--- a/src/testing/routes.py
+++ b/src/testing/routes.py
@@ -150,9 +150,9 @@ async def generate_tests_from_file(
             raise HTTPException(status_code=400, detail="No filename provided")
 
         # Read file content
-        content = await asyncio.gather(*file.read() if isinstance(file.read(, list) else (await file.read( if asyncio.iscoroutine(file.read() else file.read())
+        content_bytes = await file.read()
         try:
-            code_content = content.decode("utf-8")
+            code_content = content_bytes.decode("utf-8")
         except UnicodeDecodeError:
             raise HTTPException(status_code=400, detail="File must be UTF-8 encoded")
 


### PR DESCRIPTION
## Summary
- track A2A message counts in metrics module
- report message send/receive counts in WebSocket gateway
- document monitoring in the A2A guide and note Alembic migrations in quick start
- fix sandbox Dockerfile build step order
- fix file upload path in testing API
- test metrics in WebSocket gateway

## Testing
- `ruff check src/backend/websocket_gateway.py src/common/metrics.py src/testing/routes.py tests/unit/test_websocket_gateway.py`
- `black src/backend/websocket_gateway.py src/common/metrics.py src/testing/routes.py tests/unit/test_websocket_gateway.py`
- `mypy -m src.backend.websocket_gateway -m src.common.metrics`
- `PYTHONPATH=src python -m pytest tests/unit/test_websocket_gateway.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688ac4d202808333ab2fc1220739d53f