### PR TITLE
Add batch command to MCP CLI

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -197,6 +197,11 @@ DEBUG=true
   - `--severity <severity>`: Severity level (low|medium|high|critical)
 - `mcp verify list`: List feedback entries
 
+### Batch Execution Command
+
+- `mcp batch <file>`: Run a sequence of commands from a JSON or YAML file
+  - `--format <format>`: Specify `json` or `yaml` explicitly
+
 ## Development  
 
 ### Project Structure

--- a/cli/src/commands/batch.ts
+++ b/cli/src/commands/batch.ts
@@ -1,0 +1,44 @@
+import fs from 'fs';
+import path from 'path';
+import chalk from 'chalk';
+import yaml from 'yaml';
+import { AgentClient } from './agent';
+
+export async function run(file: string, options: { format?: string }) {
+  try {
+    const resolvedPath = path.resolve(file);
+    if (!fs.existsSync(resolvedPath)) {
+      console.error(chalk.red(`Batch file not found: ${resolvedPath}`));
+      process.exit(1);
+    }
+
+    const rawContent = fs.readFileSync(resolvedPath, 'utf8');
+    const format = options.format || (file.endsWith('.yaml') || file.endsWith('.yml') ? 'yaml' : 'json');
+    const commands: Array<{ command: string; args?: Record<string, any> }> =
+      format === 'yaml' ? yaml.parse(rawContent) : JSON.parse(rawContent);
+
+    if (!Array.isArray(commands)) {
+      console.error(chalk.red('Batch file must contain an array of commands'));
+      process.exit(1);
+    }
+
+    const client = new AgentClient();
+
+    for (const step of commands) {
+      const name = step.command;
+      const args = step.args || {};
+      console.log(chalk.blue(`\n▶ Executing: ${name} ${JSON.stringify(args)}`));
+      try {
+        await client.dispatchCommand(name, args);
+      } catch (err: any) {
+        console.error(chalk.red(`Command failed: ${err.message}`));
+        process.exit(1);
+      }
+    }
+
+    console.log(chalk.green('\n✅ Batch completed successfully'));
+  } catch (error: any) {
+    console.error(chalk.red(`Batch execution failed: ${error.message}`));
+    process.exit(1);
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -12,6 +12,7 @@ import * as verificationFeedback from './commands/verification-feedback';
 import * as configuration from './commands/configuration';
 import { interactive } from './commands/interactive';
 import { chat } from './commands/chat';
+import * as batch from './commands/batch';
 
 const packageJson = require('../package.json');
 
@@ -144,6 +145,12 @@ program
   .command('chat')
   .description('Start chat mode with AI assistant')
   .action(chat);
+
+program
+  .command('batch <file>')
+  .description('Run multiple commands from a JSON or YAML file')
+  .option('-f, --format <format>', 'Input format (json|yaml)')
+  .action(batch.run);
 
 // Configuration commands
 const listCmd = program


### PR DESCRIPTION
## Summary
- add `batch` command for executing sequences of CLI commands
- document new capability in CLI README

## Testing
- `ruff check .` *(fails: Found 59 errors)*
- `black --check .` *(fails: would reformat multiple files)*
- `mypy .`
- `pytest -q` *(fails: 30 errors during collection)*
- `npm test` in `cli`

------
https://chatgpt.com/codex/tasks/task_e_688c59489308833384f5d06d20ae27d0